### PR TITLE
Java 11 compatibility and tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ public class VernacularDemo {
         config.setRemoteClipboardListener(text -> System.out.println(String.format("Received copied text: %s", text)));
 
         // Receive screen updates from the remote host
-        // The 'image' parameter is a java.awt.Image containing a current snapshot of the remote desktop
+        // The 'image' parameter is a com.shinyhut.vernacular.client.rendering.ImageBuffer containing a current snapshot of the remote desktop
         // Expect this event to be triggered several times per second
         config.setScreenUpdateListener(image -> {
             int width = image.getWidth();

--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ public class VernacularDemo {
 }
 ```
 
-For a more realistic example, see [Vernacular Viewer](/blob/master/src/main/java/com/shinyhut/vernacular/VernacularViewer.java) in the source distribution, which demonstrates how to use Vernacular to build a working remote desktop application.
+For a more realistic example, see [Vernacular Viewer](/src/main/java/com/shinyhut/vernacular/VernacularViewer.java) in the source distribution, which demonstrates how to use Vernacular to build a working remote desktop application.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ public class VernacularDemo {
         // The 'image' parameter is a java.awt.Image containing a current snapshot of the remote desktop
         // Expect this event to be triggered several times per second
         config.setScreenUpdateListener(image -> {
-            int width = image.getWidth(null);
-            int height = image.getHeight(null);
+            int width = image.getWidth();
+            int height = image.getHeight();
             System.out.println(String.format("Received a %dx%d screen update", width, height));
         });
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,7 @@
     </scm>
 
     <properties>
-        <maven.compiler.target>21</maven.compiler.target>
-        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Thanks for publishing this to Maven Central!

Unfortunately, I couldn't use it as it was compiled to Java 21's class file format. 😅 

The code appears to be compatible with JDK 11 and later, so I've dropped the compilation target to that.